### PR TITLE
T03 — Pydantic v2 schemas

### DIFF
--- a/src/lib/schemas.py
+++ b/src/lib/schemas.py
@@ -1,0 +1,226 @@
+"""Schémas Pydantic v2 — contrat des fichiers JSON `data/parks/<id>/*.json`.
+
+GitNexus a flagué que le couplage réel entre `src/lib/*` et les pages Streamlit
+passe par les fichiers JSON sur disque, invisibles au call-graph. Ce module
+formalise ce contrat sans imposer leur usage à tous les producteurs (additif).
+
+Schémas existants (validés contre les fichiers en place) :
+- `ParkMetadata` ← `metadata.json`
+- `PVGISOutput` ← `production_estimated.json`
+- `ProductionReported` ← `production_reported.json`
+- `DeltaOutput` ← `delta.json`
+
+Schémas forward-looking (T-suivants) :
+- `LossScenario`, `ConfidenceInterval`
+- `PortfolioSweepEntry`, `PortfolioSweep`
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl, field_validator
+
+__all__ = [
+    "ParkMetadata",
+    "PVGISInputs",
+    "PVGISMetadata",
+    "PVGISOutput",
+    "ProductionReported",
+    "DeltaOutput",
+    "LossScenario",
+    "ConfidenceInterval",
+    "PortfolioSweepEntry",
+    "PortfolioSweep",
+    "Severity",
+]
+
+
+Severity = Literal["green", "yellow", "red", "unknown"]
+
+
+# ---------------------------------------------------------------------------
+# metadata.json
+# ---------------------------------------------------------------------------
+
+
+class ParkMetadata(BaseModel):
+    """Metadata d'un parc — `data/parks/<id>/metadata.json`.
+
+    Miroir du `ParkModel` de `parks_loader.py` mais en `extra="allow"` pour
+    rester additif si des champs sont ajoutés sans bumper le schéma.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    id: str = Field(..., min_length=1, description="Slug stable du parc")
+    name: str = Field(..., min_length=1)
+    country: str = Field(..., min_length=2, description="Code ISO-3166 alpha-2")
+    technology: Literal["solar", "onshore_wind", "offshore_wind", "battery_storage"]
+    coordinates: tuple[float, float] = Field(..., description="[lat, lon] en degrés")
+    capacity_mwp: Optional[float] = Field(default=None, ge=0)
+    commissioning_year: int = Field(..., ge=1980, le=2050)
+    operator: Optional[str] = None
+    allianz_stake_pct: Optional[float] = Field(default=None, ge=0, le=100)
+    acquisition_year: Optional[int] = Field(default=None, ge=1980, le=2050)
+    press_release_url: str = Field(..., min_length=1)
+    notes: Optional[str] = None
+    has_pvgis_estimate: bool = False
+    has_reported_production: bool = False
+
+    @field_validator("coordinates", mode="before")
+    @classmethod
+    def _coords_pair(cls, v: object) -> tuple[float, float]:
+        if not isinstance(v, (list, tuple)) or len(v) != 2:
+            raise ValueError("coordinates must be a [lat, lon] pair")
+        lat, lon = float(v[0]), float(v[1])
+        if not -90 <= lat <= 90:
+            raise ValueError(f"latitude {lat} hors bornes [-90, 90]")
+        if not -180 <= lon <= 180:
+            raise ValueError(f"longitude {lon} hors bornes [-180, 180]")
+        return (lat, lon)
+
+
+# ---------------------------------------------------------------------------
+# production_estimated.json (PVGIS PVcalc)
+# ---------------------------------------------------------------------------
+
+
+class PVGISInputs(BaseModel):
+    """Paramètres effectifs envoyés à PVGIS PVcalc."""
+
+    model_config = ConfigDict(extra="allow")
+
+    lat: float
+    lon: float
+    peakpower_kw: float = Field(..., ge=0)
+    tilt_deg: float
+    azimuth_deg: float
+    loss_pct: float
+    pv_technology: str
+
+
+class PVGISMetadata(BaseModel):
+    """Bloc metadata PVGIS (source + fenêtre années radiation)."""
+
+    model_config = ConfigDict(extra="allow")
+
+    source: str
+    raddatabase: Optional[str] = None
+    year_min: Optional[int] = None
+    year_max: Optional[int] = None
+
+
+class PVGISOutput(BaseModel):
+    """Sortie PVGIS sérialisée — `data/parks/<id>/production_estimated.json`.
+
+    Note: `raw_totals_fixed` reste en `dict` libre car PVGIS renvoie parfois des
+    valeurs typées variables (ex. `l_spec` est tantôt un float tantôt une string
+    `"?(0)"` quand la donnée n'est pas disponible).
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    inputs: PVGISInputs
+    monthly_production_kwh: list[float] = Field(..., min_length=12, max_length=12)
+    annual_total_kwh: float = Field(..., ge=0)
+    annual_total_mwh: float = Field(..., ge=0)
+    metadata: PVGISMetadata
+    raw_totals_fixed: Optional[dict] = None
+
+
+# ---------------------------------------------------------------------------
+# production_reported.json (seed manuel doctrine R4)
+# ---------------------------------------------------------------------------
+
+
+class ProductionReported(BaseModel):
+    """Production publiée par l'opérateur — seed manuel.
+
+    Schéma déduit de `data/parks/ourika/production_reported.json` (seul existant
+    aujourd'hui). Tous les champs documentaires sont optionnels pour rester
+    accommodant si un futur producteur omet la note ou la méthode.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    park_id: str = Field(..., min_length=1)
+    annual_total_mwh: float = Field(..., ge=0)
+    year: Optional[int] = Field(default=None, ge=1980, le=2050)
+    source: Optional[str] = None
+    url: Optional[str] = None
+    method: Optional[str] = None
+    note: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# delta.json
+# ---------------------------------------------------------------------------
+
+
+class DeltaOutput(BaseModel):
+    """Comparaison estimée vs publiée — `data/parks/<id>/delta.json`."""
+
+    model_config = ConfigDict(extra="allow")
+
+    estimated_annual_mwh: float = Field(..., ge=0)
+    reported_annual_mwh: float = Field(..., ge=0)
+    absolute_delta_mwh: float
+    relative_delta_pct: float
+    severity: Literal["green", "yellow", "red"]
+    interpretation: str
+    reported_source: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Forward-looking — Confidence intervals (multi-loss sweep PVGIS)
+# ---------------------------------------------------------------------------
+
+
+class LossScenario(BaseModel):
+    """Un scénario PVGIS à un `loss_pct` donné."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    loss_pct: float = Field(..., description="Pertes système % envoyées à PVGIS")
+    annual_kwh: float = Field(..., ge=0, description="Production annuelle correspondante (kWh)")
+
+
+class ConfidenceInterval(BaseModel):
+    """Encadrement low / mid / high de la production annuelle (MWh)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    low_mwh: float = Field(..., ge=0)
+    mid_mwh: float = Field(..., ge=0)
+    high_mwh: float = Field(..., ge=0)
+    scenarios: list[LossScenario] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Forward-looking — Portfolio sweep
+# ---------------------------------------------------------------------------
+
+
+class PortfolioSweepEntry(BaseModel):
+    """Une ligne du sweep portfolio par parc."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    park_id: str = Field(..., min_length=1)
+    capacity_mwp: Optional[float] = Field(default=None, ge=0)
+    confidence_interval: ConfidenceInterval
+    reported_mwh: Optional[float] = Field(default=None, ge=0)
+    delta_pct: Optional[float] = None
+    severity: Severity = "unknown"
+    source_url: Optional[HttpUrl] = None
+
+
+class PortfolioSweep(BaseModel):
+    """Snapshot complet du sweep portfolio (tous parcs)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    entries: list[PortfolioSweepEntry] = Field(default_factory=list)
+    generated_at: datetime

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,0 +1,119 @@
+"""Tests des schémas Pydantic v2 contre les JSON existants sur disque.
+
+Garantit la compat backwards : tout fichier déjà produit doit valider sans
+modification. Si un parc manque un fichier, le test est skippé (les seeds
+ne sont pas tous complets — solar/wind/BESS).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.lib.schemas import (
+    ConfidenceInterval,
+    DeltaOutput,
+    LossScenario,
+    ParkMetadata,
+    PortfolioSweep,
+    PortfolioSweepEntry,
+    ProductionReported,
+    PVGISOutput,
+)
+
+PARKS_DIR = Path(__file__).parent.parent / "data" / "parks"
+PARK_DIRS = sorted(d for d in PARKS_DIR.iterdir() if d.is_dir())
+
+
+@pytest.mark.parametrize("park_dir", PARK_DIRS, ids=lambda d: d.name)
+def test_metadata_validates(park_dir: Path) -> None:
+    f = park_dir / "metadata.json"
+    if not f.exists():
+        pytest.skip(f"no metadata.json in {park_dir.name}")
+    data = json.loads(f.read_text())
+    ParkMetadata.model_validate(data)
+
+
+@pytest.mark.parametrize("park_dir", PARK_DIRS, ids=lambda d: d.name)
+def test_pvgis_validates(park_dir: Path) -> None:
+    # Le précompute écrit en `production_estimated.json` (cf. pvgis_fetch.py).
+    f = park_dir / "production_estimated.json"
+    if not f.exists():
+        pytest.skip(f"no production_estimated.json in {park_dir.name}")
+    data = json.loads(f.read_text())
+    PVGISOutput.model_validate(data)
+
+
+@pytest.mark.parametrize("park_dir", PARK_DIRS, ids=lambda d: d.name)
+def test_delta_validates(park_dir: Path) -> None:
+    f = park_dir / "delta.json"
+    if not f.exists():
+        pytest.skip(f"no delta.json in {park_dir.name}")
+    data = json.loads(f.read_text())
+    DeltaOutput.model_validate(data)
+
+
+@pytest.mark.parametrize("park_dir", PARK_DIRS, ids=lambda d: d.name)
+def test_production_reported_validates(park_dir: Path) -> None:
+    f = park_dir / "production_reported.json"
+    if not f.exists():
+        pytest.skip(f"no production_reported.json in {park_dir.name}")
+    data = json.loads(f.read_text())
+    ProductionReported.model_validate(data)
+
+
+def test_confidence_interval_construction() -> None:
+    ci = ConfidenceInterval(
+        low_mwh=70000,
+        mid_mwh=75000,
+        high_mwh=80000,
+        scenarios=[
+            LossScenario(loss_pct=18.0, annual_kwh=70000000),
+            LossScenario(loss_pct=14.0, annual_kwh=75000000),
+            LossScenario(loss_pct=10.0, annual_kwh=80000000),
+        ],
+    )
+    assert ci.low_mwh < ci.mid_mwh < ci.high_mwh
+    assert len(ci.scenarios) == 3
+    assert ci.scenarios[1].loss_pct == 14.0
+
+
+def test_portfolio_sweep_entry_severity_default() -> None:
+    entry = PortfolioSweepEntry(
+        park_id="ourika",
+        capacity_mwp=46.0,
+        confidence_interval=ConfidenceInterval(
+            low_mwh=70000, mid_mwh=75000, high_mwh=80000, scenarios=[]
+        ),
+    )
+    assert entry.severity == "unknown"
+    assert entry.reported_mwh is None
+    assert entry.source_url is None
+
+
+def test_portfolio_sweep_round_trip() -> None:
+    sweep = PortfolioSweep.model_validate(
+        {
+            "entries": [
+                {
+                    "park_id": "ourika",
+                    "capacity_mwp": 46.0,
+                    "confidence_interval": {
+                        "low_mwh": 70000,
+                        "mid_mwh": 75000,
+                        "high_mwh": 80000,
+                        "scenarios": [],
+                    },
+                    "reported_mwh": 80000.0,
+                    "delta_pct": -8.13,
+                    "severity": "yellow",
+                    "source_url": "https://www.allianzcapitalpartners.com/",
+                }
+            ],
+            "generated_at": "2026-04-29T12:00:00Z",
+        }
+    )
+    assert len(sweep.entries) == 1
+    assert sweep.entries[0].severity == "yellow"


### PR DESCRIPTION
Closes #4. Closes the JSON-contract blast radius identified by GitNexus.

## Summary
- Add `src/lib/schemas.py` formalizing the `data/parks/<id>/*.json` contract — the real coupling point between `src/lib/*` and Streamlit pages, invisible to call-graph analysis.
- Existing JSON files validate WITHOUT modification (backwards compat verified by parametrized tests over all 23 parks).
- Schemas are additive — existing libs (`parks_loader.py`, `pvgis_fetch.py`, `compute_delta.py`, `sentinel_fetch.py`) are not touched.

## Schemas
**From existing JSON files:**
- `ParkMetadata` ← `metadata.json` (23/23 parks validate)
- `PVGISOutput` (+ `PVGISInputs`, `PVGISMetadata`) ← `production_estimated.json` (5/23 parks have it)
- `ProductionReported` ← `production_reported.json` (1/23 parks has it)
- `DeltaOutput` ← `delta.json` (1/23 parks has it)

**Forward-looking (T-suivants):**
- `LossScenario`, `ConfidenceInterval`
- `PortfolioSweepEntry`, `PortfolioSweep`
- `Severity = Literal["green","yellow","red","unknown"]`

## Notes
- Spec mentioned `pvgis.json` but the actual filename written by `pvgis_fetch.py`/`precompute_all.py` is `production_estimated.json`. Tests use the actual filename to validate against existing data.
- `PVGISOutput.raw_totals_fixed` kept as a free `dict` because PVGIS occasionally returns string sentinels (e.g. `l_spec: "?(0)"`) — typing it strictly would break backwards compat.

## Test plan
- [x] `pytest tests/test_schemas.py -v` — 33 passed, 62 skipped (parks without optional artefacts)
- [x] `pytest tests/ -v` — 86 passed, 62 skipped (≥ 64 target met)
- [x] No JSON file required modification to validate

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>